### PR TITLE
Add output for OIDC identity provider issuer

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -5,3 +5,7 @@ output "worker_role_arn" {
 output "private_subnet_ids" {
   value = data.aws_subnet_ids.private.ids
 }
+
+output "oidc_identity_provider_issuer" {
+  value = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+}


### PR DESCRIPTION
The OIDC identity provider issuer is required to be able to link IAM roles to k8s service accounts. See: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html