### PR TITLE
Provide log group name

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -25,7 +25,7 @@ resource "aws_eks_cluster" "cluster" {
 }
 
 resource "aws_cloudwatch_log_group" "control_plane_logs" {
-  name              = "/aws/eks/${var.cluster_name}/cluster"
+  name              = "/aws/eks/${local.log_group_name}/cluster"
   retention_in_days = 30
 
   tags = var.tags

--- a/examples/basic/cluster.tf
+++ b/examples/basic/cluster.tf
@@ -4,7 +4,7 @@ module "cluster" {
   cluster_name       = "simple-eks-integration-test"
   cluster_version    = "1.18"
   vpc_name           = var.vpc_name
-  #log_group_name    = "a-test-log-group-name"
+  log_group_name     = "a-test-log-group-name"
 
   region  = var.aws_region
   profile = var.aws_profile

--- a/examples/basic/cluster.tf
+++ b/examples/basic/cluster.tf
@@ -4,6 +4,7 @@ module "cluster" {
   cluster_name       = "simple-eks-integration-test"
   cluster_version    = "1.18"
   vpc_name           = var.vpc_name
+  #log_group_name    = "a-test-log-group-name"
 
   region  = var.aws_region
   profile = var.aws_profile

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  log_group_name = var.log_group_name == "" ? var.cluster_name : var.log_group_name
+  log_group_name = var.log_group_name == null ? var.cluster_name : var.log_group_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  log_group_name = var.log_group_name == "" ? var.cluster_name : var.log_group_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "cluster_name" {
 # log group name will be var.cluster_name
 variable "log_group_name" {
   type    = string
-  default = ""
+  default = null
 }
 
 variable "cluster_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,13 @@ variable "cluster_name" {
   type = string
 }
 
+# If this variable is an empty string, the
+# log group name will be var.cluster_name
+variable "log_group_name" {
+  type    = string
+  default = ""
+}
+
 variable "cluster_version" {
   type = string
 }


### PR DESCRIPTION
Enable users to provide a different log group name.
If left empty (default), then the name of the log group will be the cluster's name.