### PR TITLE
Enable private endpoint access

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -1,7 +1,3 @@
-locals {
-  private_endpoint_enabled = length(var.public_access_cidrs) > 0 ? true : false
-}
-
 resource "aws_eks_cluster" "cluster" {
   name     = var.cluster_name
   role_arn = aws_iam_role.role.arn
@@ -9,7 +5,7 @@ resource "aws_eks_cluster" "cluster" {
   vpc_config {
     subnet_ids = data.aws_subnet_ids.private.ids
 
-    endpoint_private_access = local.private_endpoint_enabled
+    endpoint_private_access = var.private_endpoint_enabled
     endpoint_public_access  = true
     public_access_cidrs     = var.public_access_cidrs
   }

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,9 +1,17 @@
+locals {
+  private_endpoint_enabled = length(var.public_access_cidrs) > 0 ? true : false
+}
+
 resource "aws_eks_cluster" "cluster" {
   name     = var.cluster_name
   role_arn = aws_iam_role.role.arn
 
   vpc_config {
     subnet_ids = data.aws_subnet_ids.private.ids
+
+    endpoint_private_access = local.private_endpoint_enabled
+    endpoint_public_access  = true
+    public_access_cidrs     = var.public_access_cidrs
   }
 
   version = var.cluster_version

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,12 @@ variable "cluster_log_types" {
   }
 }
 
+variable "private_endpoint_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "public_access_cidrs" {
   type    = list(string)
-  default = []
+  default = ["0.0.0.0/0"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,11 +29,16 @@ variable "use_calico_cni" {
 }
 
 variable "cluster_log_types" {
-  type       = list(string)
-  default    = ["api", "authenticator"]
+  type    = list(string)
+  default = ["api", "authenticator"]
 
   validation {
-    condition      = length(setsubtract(var.cluster_log_types, ["api", "audit", "authenticator", "controllerManager", "scheduler"])) == 0
-    error_message  = "Control plane logs can only be a list containing any of api, audit, authenticator, controllerManager or scheduler."
+    condition     = length(setsubtract(var.cluster_log_types, ["api", "audit", "authenticator", "controllerManager", "scheduler"])) == 0
+    error_message = "Control plane logs can only be a list containing any of api, audit, authenticator, controllerManager or scheduler."
   }
+}
+
+variable "public_access_cidrs" {
+  type    = list(string)
+  default = []
 }


### PR DESCRIPTION
A list of public access CIDRs enables the access private endpoint to the EKS cluster.